### PR TITLE
fix init image latent scale

### DIFF
--- a/train_svd.py
+++ b/train_svd.py
@@ -1000,6 +1000,8 @@ def main():
                 )
                 latents = tensor_to_vae_latent(pixel_values, vae)
                 conditional_latents = latents[:, 0, :, :, :]
+                conditional_latents = conditional_latents / vae.config.scaling_factor
+        
                 # Sample noise that we'll add to the latents
                 noise = torch.randn_like(latents)
                 bsz = latents.shape[0]


### PR DESCRIPTION
As you can see here:
https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/stable_video_diffusion/pipeline_stable_video_diffusion.py

during the forward pass, the init image shouldn't be scaled by the vae.config.scaling_factor, only the latents