### PR TITLE
Fix timesteps device

### DIFF
--- a/train_svd.py
+++ b/train_svd.py
@@ -1013,7 +1013,7 @@ def main():
                 noisy_latents = latents + noise * sigmas
                 timesteps = torch.Tensor(
                     [0.25 * sigma.log() for sigma in sigmas]).to(accelerator.device)
- 
+
                 inp_noisy_latents = noisy_latents / ((sigmas**2 + 1) ** 0.5)
 
                 # Get the text embedding for conditioning.

--- a/train_svd.py
+++ b/train_svd.py
@@ -1012,8 +1012,8 @@ def main():
                 # (this is the forward diffusion process)
                 noisy_latents = latents + noise * sigmas
                 timesteps = torch.Tensor(
-                    [0.25 * sigma.log() for sigma in sigmas])
-
+                    [0.25 * sigma.log() for sigma in sigmas]).to(accelerator.device)
+ 
                 inp_noisy_latents = noisy_latents / ((sigmas**2 + 1) ** 0.5)
 
                 # Get the text embedding for conditioning.


### PR DESCRIPTION
Set the device of the timesteps to that of the accelerator. This way the timesteps and the model weights are on the same device. This fix enabled me to finetune the unet without errors. :)