### PR TITLE
enable autocast for bf16 as well

### DIFF
--- a/train_svd.py
+++ b/train_svd.py
@@ -1185,7 +1185,7 @@ def main():
                             os.makedirs(val_save_dir)
 
                         with torch.autocast(
-                            str(accelerator.device).replace(":0", ""), enabled=accelerator.mixed_precision == "fp16"
+                            str(accelerator.device).replace(":0", ""), enabled=accelerator.mixed_precision != "no"
                         ):
                             for val_img_idx in range(args.num_validation_images):
                                 num_frames = args.num_frames


### PR DESCRIPTION
In my experiments with A100, I have seen type mismatch errors when bf16 is selected. Which I believe is a bug and this simple change fixed it for me.